### PR TITLE
HCK-12580: enabled <extensions> on references

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -250,7 +250,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"string": [
@@ -547,7 +599,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"number": [
@@ -848,7 +952,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"integer": [
@@ -1149,7 +1305,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"boolean": [
@@ -1305,7 +1513,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"array": [
@@ -1551,8 +1811,74 @@ making sure that you maintain a proper JSON format.
 					}
 				],
 				"dependency": {
-					"key": "subtype",
-					"value": "schema"
+					"type": "and",
+					"values": [
+						{
+							"key": "subtype",
+							"value": "schema"
+						},
+						{
+							"type": "not",
+							"values": [
+								{
+									"key": "refType",
+									"value": "polyglot"
+								},
+								{
+									"key": "refType",
+									"value": "external"
+								}
+							]
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "subtype",
+							"value": "schema"
+						},
+						{
+							"type": "or",
+							"values": [
+								{
+									"key": "refType",
+									"value": "polyglot"
+								},
+								{
+									"key": "refType",
+									"value": "external"
+								}
+							]
+						}
+					]
 				}
 			},
 			"comments"
@@ -1906,8 +2232,74 @@ making sure that you maintain a proper JSON format.
 					}
 				],
 				"dependency": {
-					"key": "subtype",
-					"value": "schema"
+					"type": "and",
+					"values": [
+						{
+							"key": "subtype",
+							"value": "schema"
+						},
+						{
+							"type": "not",
+							"values": [
+								{
+									"key": "refType",
+									"value": "polyglot"
+								},
+								{
+									"key": "refType",
+									"value": "external"
+								}
+							]
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "subtype",
+							"value": "schema"
+						},
+						{
+							"type": "or",
+							"values": [
+								{
+									"key": "refType",
+									"value": "polyglot"
+								},
+								{
+									"key": "refType",
+									"value": "external"
+								}
+							]
+						}
+					]
 				}
 			},
 			"comments"
@@ -1968,7 +2360,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"response": [
@@ -2041,7 +2485,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"media": [
@@ -2181,7 +2677,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"encoding": [
@@ -2248,7 +2796,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"example": [
@@ -2301,7 +2901,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"header": [
@@ -2378,7 +3030,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"securityScheme": [
@@ -2812,7 +3516,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"callback": [
@@ -2876,7 +3632,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"link": [
@@ -3039,7 +3847,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"expression": [
@@ -3150,7 +4010,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"parameter (query)": [
@@ -3228,7 +4140,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"parameter (header)": [
@@ -3306,7 +4270,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"parameter (cookie)": [
@@ -3384,7 +4400,59 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"choice": [

--- a/reverse_engineering/helpers/dataHelper.js
+++ b/reverse_engineering/helpers/dataHelper.js
@@ -25,6 +25,10 @@ const getExtensions = schema => {
 
 const getExtensionsObject = (data, keyword = 'scopesExtensions') => {
 	const extensions = getExtensions(data);
+	if (extensions.length === 0) {
+		return {};
+	}
+
 	return { [keyword]: extensions };
 };
 
@@ -69,13 +73,14 @@ const getServersData = servers => {
 		}
 
 		const variables = server.variables ? getServersVariables(server.variables) : [];
+		const extensions = getExtensions(server);
 		return [
 			...accum,
 			{
 				serverURL: server.url,
 				serverDescription: server.description,
 				serverVariables: variables,
-				scopesExtensions: getExtensions(server),
+				...(extensions.length > 0 && { scopesExtensions: extensions }),
 			},
 		];
 	}, []);
@@ -84,12 +89,13 @@ const getServersData = servers => {
 const getServersVariables = variables => {
 	return Object.keys(variables).map(variable => {
 		const variableData = variables[variable];
+		const extensions = getExtensions(variables);
 		return {
 			serverVariableName: variable,
 			serverVariableEnum: (variableData.enum || []).map(enumVal => ({ serverVariableEnumValue: enumVal })),
 			serverVariableDefault: variableData.default,
 			serverVariableDescription: variableData.description,
-			scopesExtensions: getExtensions(variables),
+			...(extensions.length > 0 && { scopesExtensions: extensions }),
 		};
 	}, []);
 };
@@ -604,7 +610,7 @@ const handleSchemaExtensions = schema => {
 	const mappedExtensionsObject = getExtensionsObject(schema);
 	if (
 		!Array.isArray(mappedExtensionsObject.scopesExtensions) ||
-		mappedExtensionsObject.scopesExtensions.length === 0
+		mappedExtensionsObject.scopesExtensions?.length === 0
 	) {
 		return schema;
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12580" title="HCK-12580" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-12580</a>  [0;5] Update EventBridge
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

We want to allow the user change "extensions" property on the references, it is mainly valuable in external and cross-target references.