### PR TITLE
chore: address Trivy production dependency vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "EventBridge",
-    "version": "0.2.15",
+    "version": "0.2.16",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "EventBridge",
-            "version": "0.2.15",
+            "version": "0.2.16",
             "hasInstallScript": true,
             "dependencies": {
                 "@apidevtools/swagger-parser": "12.1.0",
                 "@aws-sdk/client-schemas": "3.1045.0",
                 "@hackolade/fetch": "1.1.0",
                 "comment-json": "4.1.0",
-                "js-yaml": "4.2.0",
+                "js-yaml": "4.3.0",
                 "lodash.get": "4.4.2",
                 "lodash.isplainobject": "4.0.6",
                 "lodash.partial": "4.2.1",
@@ -2545,16 +2545,16 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -2878,9 +2878,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
             "funding": [
                 {
                     "type": "github",
@@ -3186,9 +3186,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "funding": [
                 {
                     "type": "github",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
         "@aws-sdk/client-schemas": "3.1045.0",
         "@hackolade/fetch": "1.1.0",
         "comment-json": "4.1.0",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.0",
         "lodash.get": "4.4.2",
         "lodash.isplainobject": "4.0.6",
         "lodash.partial": "4.2.1",
@@ -125,6 +125,7 @@
     "overrides": {
         "minimatch": "10.2.4",
         "fast-xml-parser": "5.7.3",
-        "fast-uri": "3.1.2"
+        "fast-uri": "3.1.4",
+        "brace-expansion": "5.0.8"
     }
 }


### PR DESCRIPTION
## Summary
- Address Trivy dependency vulnerabilities for `EventBridge`: js-yaml 4.2.0 → 4.3.0, fast-uri override 3.1.2 → 3.1.4 (+ brace-expansion override).
- This plugin was listed in the Plugins develop Trivy production report (build 284434).
- Reference: https://teamcity.hackolade.com/buildConfiguration/Plugins_Build/284434

## Test plan
- [ ] CI passes
- [ ] Plugins develop Trivy re-scan no longer reports the fixed packages for production-impacted plugins
